### PR TITLE
Make Client::close drop explicit

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -79,7 +79,9 @@ impl<T: JackHandler> Client<T> {
     /// Disconnects the client from the Jack server. This does not need to
     /// manually be called, as the client will automatically close when the
     /// client object is dropped.
-    pub fn close(self) {}
+    pub fn close(self) {
+        drop(self)
+    }
 
     /// Get the status of the client.
     pub fn status(&self) -> ClientStatus {


### PR DESCRIPTION
This call is technically redundant, but its omission was confusing when I was first looking at the code, leading to the creation and subsequent closing of #13.