### PR TITLE
[WIP] Safe Port / buffer access

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Will S. Medrano <will.s.medrano@gmail.com>"]
 
 [dependencies]
 bitflags = "0.7.0"
-jack-sys = "0.1.0"
+jack-sys = { git = "https://github.com/cramertj/jack-sys.git", branch = "cramertj/unsafe-extern" }
 libc = "0.2"

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -63,7 +63,7 @@ fn read_freq() -> Option<f64> {
 }
 
 fn main() {
-    let mut client = jack::Client::open("rust_jack_sine", jack::NO_START_SERVER).unwrap();
+    let (mut client, _status) = jack::Client::open("rust_jack_sine", jack::NO_START_SERVER).unwrap();
 
     let out_port = client.register_port("sine_out", jack::DEFAULT_AUDIO_TYPE, jack::IS_OUTPUT, None)
         .unwrap();

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -7,14 +7,14 @@ use std::str::FromStr;
 pub struct SinWave {
     frame_t: f64,
     frequency: f64,
-    out_port: jack::Port<jack::Output>,
+    out_port: jack::Port<jack::Owned<jack::Output<jack::Audio>>>,
     time: f64,
     receiver: Receiver<f64>,
     sender: Sender<f64>,
 }
 
 impl SinWave {
-    pub fn new(out_port: jack::Port<jack::Output>, freq: f64, sample_rate: f64) -> Self {
+    pub fn new(out_port: jack::Port<jack::Owned<jack::Output<jack::Audio>>>, freq: f64, sample_rate: f64) -> Self {
         let (tx, rx) = channel();
         SinWave {
             frame_t: 1.0 / sample_rate,
@@ -66,8 +66,7 @@ fn read_freq() -> Option<f64> {
 fn main() {
     let (mut client, _status) = jack::Client::open("rust_jack_sine", jack::NO_START_SERVER).unwrap();
 
-    let out_port = client.register_port("sine_out", jack::DEFAULT_AUDIO_TYPE, jack::IS_OUTPUT, None)
-        .unwrap();
+    let out_port = client.register_port("sine_out", jack::IS_OUTPUT, None).unwrap();
     let app = SinWave::new(out_port, 220.0, client.sample_rate() as f64);
     let freq_request = app.frequency_requester();
     let active_client = client.activate(app).unwrap();

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -4,6 +4,28 @@ use jack_sys as j;
 use enums::*;
 use flags::*;
 
+pub struct ProcessScope {
+    // To be used _only_ for runtime verification that the client who wrote
+    // that the only ports being used are ones created by the client whose
+    // handler is being run.
+    client: *mut j::jack_client_t,
+
+    // Used to allow safe access to IO port buffers
+    n_frames: u32,
+}
+
+impl ProcessScope {
+    #[inline(always)]
+    pub fn client_equals(&self, client: *mut j::jack_client_t) -> bool {
+        self.client == client
+    }
+
+    #[inline(always)]
+    pub fn n_frames(&self) -> u32 {
+        self.n_frames
+    }
+}
+
 /// Specifies callbacks for Jack.
 ///
 /// All callbacks happen on the same thread (not concurrently), unless otherwise
@@ -11,7 +33,7 @@ use flags::*;
 ///
 /// # TODO
 /// * convert C enum return values to Rust enums.
-pub trait JackHandler {
+pub trait JackHandler: Send {
     /// Called just once after the creation of the thread in which all other
     /// callbacks will be handled.
     ///
@@ -35,7 +57,8 @@ pub trait JackHandler {
     /// pthread_cond_wait, etc, etc.
     ///
     /// Should return `0` on success, and non-zero on error.
-    fn process(&mut self, _n_frames: u32) -> JackControl {
+    fn process(&mut self, process_scope: &mut ProcessScope) -> JackControl {
+        let _ = process_scope;
         JackControl::Continue
     }
 
@@ -134,119 +157,122 @@ pub trait JackHandler {
     fn latency(&mut self, _mode: LatencyType) {}
 }
 
-unsafe fn from_void<'a, T: JackHandler>(ptr: *mut c_void) -> &'a mut T {
+unsafe fn from_void<'a, T: JackHandler>(ptr: *mut c_void) ->
+        &'a mut (T, *mut j::jack_client_t) {
     assert!(!ptr.is_null());
-    let obj_ptr: *mut T = mem::transmute(ptr);
+    let obj_ptr: *mut (T, *mut j::jack_client_t) = mem::transmute(ptr);
     &mut *obj_ptr
 }
 
-extern "C" fn thread_init_callback<T: JackHandler>(data: *mut c_void) {
-    let obj: &mut T = unsafe { from_void(data) };
-    obj.thread_init()
+unsafe extern "C" fn thread_init_callback<T: JackHandler>(data: *mut c_void) {
+    let obj: &mut (T, _) = from_void(data);
+    obj.0.thread_init()
 }
 
-extern "C" fn shutdown<T: JackHandler>(code: j::jack_status_t,
+unsafe extern "C" fn shutdown<T: JackHandler>(code: j::jack_status_t,
                                        reason: *const i8,
                                        data: *mut c_void) {
-    let obj: &mut T = unsafe { from_void(data) };
-    let reason_str = unsafe {
-        let cstr = ffi::CStr::from_ptr(reason);
-        match cstr.to_str() {
-            Ok(s) => s,
-            Err(_) => "Failed to interpret error.",
-        }
+    let obj: &mut (T, _) = from_void(data);
+    let cstr = ffi::CStr::from_ptr(reason);
+    let reason_str = match cstr.to_str() {
+        Ok(s) => s,
+        Err(_) => "Failed to interpret error.",
     };
-    obj.shutdown(ClientStatus::from_bits(code).unwrap_or(UNKNOWN_ERROR),
+    obj.0.shutdown(ClientStatus::from_bits(code).unwrap_or(UNKNOWN_ERROR),
                  reason_str)
 }
 
-extern "C" fn process<T: JackHandler>(n_frames: u32, data: *mut c_void) -> i32 {
-    let obj: &mut T = unsafe { from_void(data) };
-    obj.process(n_frames).to_ffi()
+unsafe extern "C" fn process<T: JackHandler>(n_frames: u32, data: *mut c_void) -> i32 {
+    let obj: &mut (T, *mut j::jack_client_t) = from_void(data);
+    let mut scope = ProcessScope {
+        client: obj.1,
+        n_frames: n_frames,
+    };
+    obj.0.process(&mut scope).to_ffi()
 }
 
-extern "C" fn freewheel<T: JackHandler>(starting: i32, data: *mut c_void) {
-    let obj: &mut T = unsafe { from_void(data) };
+unsafe extern "C" fn freewheel<T: JackHandler>(starting: i32, data: *mut c_void) {
+    let obj: &mut (T, _) = from_void(data);
     let is_starting = match starting {
         0 => false,
         _ => true,
     };
-    obj.freewheel(is_starting)
+    obj.0.freewheel(is_starting)
 }
 
-extern "C" fn buffer_size<T: JackHandler>(n_frames: u32, data: *mut c_void) -> i32 {
-    let obj: &mut T = unsafe { from_void(data) };
-    obj.buffer_size(n_frames).to_ffi()
+unsafe extern "C" fn buffer_size<T: JackHandler>(n_frames: u32, data: *mut c_void) -> i32 {
+    let obj: &mut (T, _) = from_void(data);
+    obj.0.buffer_size(n_frames).to_ffi()
 }
 
-extern "C" fn sample_rate<T: JackHandler>(n_frames: u32, data: *mut c_void) -> i32 {
-    let obj: &mut T = unsafe { from_void(data) };
-    obj.sample_rate(n_frames).to_ffi()
+unsafe extern "C" fn sample_rate<T: JackHandler>(n_frames: u32, data: *mut c_void) -> i32 {
+    let obj: &mut (T, _) = from_void(data);
+    obj.0.sample_rate(n_frames).to_ffi()
 }
 
-extern "C" fn client_registration<T: JackHandler>(name: *const i8,
+unsafe extern "C" fn client_registration<T: JackHandler>(name: *const i8,
                                                   register: i32,
                                                   data: *mut c_void) {
-    let obj: &mut T = unsafe { from_void(data) };
-    let name = unsafe { ffi::CStr::from_ptr(name).to_str().unwrap() };
+    let obj: &mut (T, _) = from_void(data);
+    let name = ffi::CStr::from_ptr(name).to_str().unwrap();
     let register = match register {
         0 => false,
         _ => true,
     };
-    obj.client_registration(name, register)
+    obj.0.client_registration(name, register)
 }
 
-extern "C" fn port_registration<T: JackHandler>(port_id: u32, register: i32, data: *mut c_void) {
-    let obj: &mut T = unsafe { from_void(data) };
+unsafe extern "C" fn port_registration<T: JackHandler>(port_id: u32, register: i32, data: *mut c_void) {
+    let obj: &mut (T, _) = from_void(data);
     let register = match register {
         0 => false,
         _ => true,
     };
-    obj.port_registration(port_id, register)
+    obj.0.port_registration(port_id, register)
 }
 
 #[allow(dead_code)] // TODO: remove once it can be registered
-extern "C" fn port_rename<T: JackHandler>(port_id: u32,
+unsafe extern "C" fn port_rename<T: JackHandler>(port_id: u32,
                                           old_name: *const i8,
                                           new_name: *const i8,
                                           data: *mut c_void)
                                           -> i32 {
-    let obj: &mut T = unsafe { from_void(data) };
-    let old_name = unsafe { ffi::CStr::from_ptr(old_name).to_str().unwrap() };
-    let new_name = unsafe { ffi::CStr::from_ptr(new_name).to_str().unwrap() };
-    obj.port_rename(port_id, old_name, new_name).to_ffi()
+    let obj: &mut (T, _) = from_void(data);
+    let old_name = ffi::CStr::from_ptr(old_name).to_str().unwrap();
+    let new_name = ffi::CStr::from_ptr(new_name).to_str().unwrap();
+    obj.0.port_rename(port_id, old_name, new_name).to_ffi()
 }
 
-extern "C" fn port_connect<T: JackHandler>(port_id_a: u32,
+unsafe extern "C" fn port_connect<T: JackHandler>(port_id_a: u32,
                                            port_id_b: u32,
                                            connect: i32,
                                            data: *mut c_void) {
-    let obj: &mut T = unsafe { from_void(data) };
+    let obj: &mut (T, _) = from_void(data);
     let are_connected = match connect {
         0 => false,
         _ => true,
     };
-    obj.ports_connected(port_id_a, port_id_b, are_connected)
+    obj.0.ports_connected(port_id_a, port_id_b, are_connected)
 }
 
-extern "C" fn graph_order<T: JackHandler>(data: *mut c_void) -> i32 {
-    let obj: &mut T = unsafe { from_void(data) };
-    obj.graph_reorder().to_ffi()
+unsafe extern "C" fn graph_order<T: JackHandler>(data: *mut c_void) -> i32 {
+    let obj: &mut (T, _) = from_void(data);
+    obj.0.graph_reorder().to_ffi()
 }
 
-extern "C" fn xrun<T: JackHandler>(data: *mut c_void) -> i32 {
-    let obj: &mut T = unsafe { from_void(data) };
-    obj.xrun().to_ffi()
+unsafe extern "C" fn xrun<T: JackHandler>(data: *mut c_void) -> i32 {
+    let obj: &mut (T, _) = from_void(data);
+    obj.0.xrun().to_ffi()
 }
 
-extern "C" fn latency<T: JackHandler>(mode: j::jack_latency_callback_mode_t, data: *mut c_void) {
-    let obj: &mut T = unsafe { from_void(data) };
+unsafe extern "C" fn latency<T: JackHandler>(mode: j::jack_latency_callback_mode_t, data: *mut c_void) {
+    let obj: &mut (T, _) = from_void(data);
     let mode = match mode {
         j::JackCaptureLatency => LatencyType::Capture,
         j::JackPlaybackLatency => LatencyType::Playback,
         _ => unreachable!(),
     };
-    obj.latency(mode)
+    obj.0.latency(mode)
 }
 
 /// Clears the callbacks registered to `client`.
@@ -269,6 +295,8 @@ pub unsafe fn clear_callbacks(_client: *mut j::jack_client_t) -> Result<(), Jack
 /// Returns `Ok(handler_ptr)` on success, or
 /// `Err(JackErr::CallbackRegistrationError)` on failure.
 ///
+/// `handler_ptr` here is a pointer to a heap-allocated pair `(T, *mut j::jack_client_t)`.
+///
 /// Registers `handler` with jack. All jack calls to `client` will be handled by
 /// `handler`. `handler` is consumed, but it is not deallocated. `handler`
 /// should be manually deallocated when jack will no longer make calls to it,
@@ -283,8 +311,9 @@ pub unsafe fn clear_callbacks(_client: *mut j::jack_client_t) -> Result<(), Jack
 /// * `handler` will not be automatically deallocated.
 pub unsafe fn register_callbacks<T: JackHandler>(client: *mut j::jack_client_t,
                                                  handler: T)
-                                                 -> Result<*mut T, JackErr> {
-    let handler_ptr: *mut T = Box::into_raw(Box::new(handler));
+                                                 -> Result<*mut (T, *mut j::jack_client_t), JackErr> {
+    let handler_ptr: *mut (T, *mut j::jack_client_t) =
+        Box::into_raw(Box::new((handler, client)));
     let data_ptr = mem::transmute(handler_ptr);
     j::jack_set_thread_init_callback(client, Some(thread_init_callback::<T>), data_ptr);
     j::jack_on_info_shutdown(client, Some(shutdown::<T>), data_ptr);

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -24,8 +24,8 @@ pub trait JackHandler {
     /// another thread. A typical funcion might set a flag or write to a pipe so
     /// that the rest of the application knows that the Jack client thread has
     /// shut down.
-
     fn shutdown(&mut self, _status: ClientStatus, _reason: &str) {}
+
     /// Called whenever there is work to be done.
     ///
     /// It needs to be suitable for real-time execution. That means that it

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -159,8 +159,7 @@ pub trait JackHandler: Send {
     fn latency(&mut self, _mode: LatencyType) {}
 }
 
-unsafe fn handler_and_id_from_void<'a, T: JackHandler>(ptr: *mut c_void) ->
-        &'a mut (T, ClientId) {
+unsafe fn handler_and_id_from_void<'a, T: JackHandler>(ptr: *mut c_void) -> &'a mut (T, ClientId) {
     assert!(!ptr.is_null());
     let obj_ptr: *mut (T, ClientId) = mem::transmute(ptr);
     &mut *obj_ptr
@@ -172,8 +171,8 @@ unsafe extern "C" fn thread_init_callback<T: JackHandler>(data: *mut c_void) {
 }
 
 unsafe extern "C" fn shutdown<T: JackHandler>(code: j::jack_status_t,
-                                       reason: *const i8,
-                                       data: *mut c_void) {
+                                              reason: *const i8,
+                                              data: *mut c_void) {
     let obj: &mut (T, _) = handler_and_id_from_void(data);
     let cstr = ffi::CStr::from_ptr(reason);
     let reason_str = match cstr.to_str() {
@@ -181,7 +180,7 @@ unsafe extern "C" fn shutdown<T: JackHandler>(code: j::jack_status_t,
         Err(_) => "Failed to interpret error.",
     };
     obj.0.shutdown(ClientStatus::from_bits(code).unwrap_or(UNKNOWN_ERROR),
-                 reason_str)
+                   reason_str)
 }
 
 unsafe extern "C" fn process<T: JackHandler>(n_frames: u32, data: *mut c_void) -> i32 {
@@ -213,8 +212,8 @@ unsafe extern "C" fn sample_rate<T: JackHandler>(n_frames: u32, data: *mut c_voi
 }
 
 unsafe extern "C" fn client_registration<T: JackHandler>(name: *const i8,
-                                                  register: i32,
-                                                  data: *mut c_void) {
+                                                         register: i32,
+                                                         data: *mut c_void) {
     let obj: &mut (T, _) = handler_and_id_from_void(data);
     let name = ffi::CStr::from_ptr(name).to_str().unwrap();
     let register = match register {
@@ -225,7 +224,9 @@ unsafe extern "C" fn client_registration<T: JackHandler>(name: *const i8,
 }
 
 
-unsafe extern "C" fn port_registration<T: JackHandler>(port_id: u32, register: i32, data: *mut c_void) {
+unsafe extern "C" fn port_registration<T: JackHandler>(port_id: u32,
+                                                       register: i32,
+                                                       data: *mut c_void) {
     let obj: &mut (T, _) = handler_and_id_from_void(data);
     let register = match register {
         0 => false,
@@ -236,10 +237,10 @@ unsafe extern "C" fn port_registration<T: JackHandler>(port_id: u32, register: i
 
 #[allow(dead_code)] // TODO: remove once it can be registered
 unsafe extern "C" fn port_rename<T: JackHandler>(port_id: u32,
-                                          old_name: *const i8,
-                                          new_name: *const i8,
-                                          data: *mut c_void)
-                                          -> i32 {
+                                                 old_name: *const i8,
+                                                 new_name: *const i8,
+                                                 data: *mut c_void)
+                                                 -> i32 {
     let obj: &mut (T, _) = handler_and_id_from_void(data);
     let old_name = ffi::CStr::from_ptr(old_name).to_str().unwrap();
     let new_name = ffi::CStr::from_ptr(new_name).to_str().unwrap();
@@ -247,9 +248,9 @@ unsafe extern "C" fn port_rename<T: JackHandler>(port_id: u32,
 }
 
 unsafe extern "C" fn port_connect<T: JackHandler>(port_id_a: u32,
-                                           port_id_b: u32,
-                                           connect: i32,
-                                           data: *mut c_void) {
+                                                  port_id_b: u32,
+                                                  connect: i32,
+                                                  data: *mut c_void) {
     let obj: &mut (T, _) = handler_and_id_from_void(data);
     let are_connected = match connect {
         0 => false,
@@ -268,7 +269,8 @@ unsafe extern "C" fn xrun<T: JackHandler>(data: *mut c_void) -> i32 {
     obj.0.xrun().to_ffi()
 }
 
-unsafe extern "C" fn latency<T: JackHandler>(mode: j::jack_latency_callback_mode_t, data: *mut c_void) {
+unsafe extern "C" fn latency<T: JackHandler>(mode: j::jack_latency_callback_mode_t,
+                                             data: *mut c_void) {
     let obj: &mut (T, _) = handler_and_id_from_void(data);
     let mode = match mode {
         j::JackCaptureLatency => LatencyType::Capture,
@@ -316,8 +318,7 @@ pub unsafe fn register_callbacks<T: JackHandler>(handler: T,
                                                  client: *mut j::jack_client_t,
                                                  client_id: ClientId)
                                                  -> Result<*mut (T, ClientId), JackErr> {
-    let handler_ptr: *mut (T, ClientId) =
-        Box::into_raw(Box::new((handler, client_id)));
+    let handler_ptr: *mut (T, ClientId) = Box::into_raw(Box::new((handler, client_id)));
     let data_ptr = mem::transmute(handler_ptr);
     j::jack_set_thread_init_callback(client, Some(thread_init_callback::<T>), data_ptr);
     j::jack_on_info_shutdown(client, Some(shutdown::<T>), data_ptr);

--- a/src/client.rs
+++ b/src/client.rs
@@ -138,7 +138,7 @@ impl<T: JackHandler> Client<T> {
         }
     }
 
-    /// Returns a vector of ports that match the specified arguments
+    /// Returns a vector of port names that match the specified arguments
     ///
     /// `port_name_pattern` - A regular expression used to select ports by
     /// name. If `None` or zero lengthed, no selection based on name will be

--- a/src/client.rs
+++ b/src/client.rs
@@ -79,7 +79,9 @@ impl<T: JackHandler> Client<T> {
     /// Disconnects the client from the Jack server. This does not need to
     /// manually be called, as the client will automatically close when the
     /// client object is dropped.
-    pub fn close(self) {}
+    pub fn close(self) {
+        drop(self)
+    }
 
     /// Get the status of the client.
     pub fn status(&self) -> ClientStatus {

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -38,7 +38,7 @@ impl JackControl {
     pub fn to_ffi(self) -> i32 {
         match self {
             JackControl::Continue => 0,
-            JackControl::Quit     => -1,
+            JackControl::Quit => -1,
         }
     }
 }

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -122,6 +122,7 @@ bitflags! {
     /// synthesizers, I/O hardware interface clients, HDR systems are examples
     /// of clients that would set this flag for their ports.
     pub flags PortFlags: u32 {
+        const NO_PORT_FLAGS = 0,
         const IS_INPUT    = j::JackPortIsInput,
         const IS_OUTPUT   = j::JackPortIsOutput,
         const IS_PHYSICAL = j::JackPortIsPhysical,

--- a/src/info.rs
+++ b/src/info.rs
@@ -14,18 +14,14 @@ fn to_stderr(msg: &str) {
 static mut info_fn: fn (&str) = to_stdout;
 static mut error_fn: fn (&str) = to_stderr;
 
-extern "C" fn error_wrapper(msg: *const i8) {
-    unsafe {
-        let msg = ffi::CStr::from_ptr(msg).to_str().unwrap();
-        error_fn(msg);
-    };
+unsafe extern "C" fn error_wrapper(msg: *const i8) {
+    let msg = ffi::CStr::from_ptr(msg).to_str().unwrap();
+    error_fn(msg);
 }
 
-extern "C" fn info_wrapper(msg: *const i8) {
-    unsafe {
-        let msg = ffi::CStr::from_ptr(msg).to_str().unwrap();
-        info_fn(msg)
-    };
+unsafe extern "C" fn info_wrapper(msg: *const i8) {
+    let msg = ffi::CStr::from_ptr(msg).to_str().unwrap();
+    info_fn(msg)
 }
 
 static ARE_CALLBACKS_SET: Once = ONCE_INIT;

--- a/src/info.rs
+++ b/src/info.rs
@@ -11,8 +11,8 @@ fn to_stderr(msg: &str) {
     writeln!(&mut stderr(), "{}", msg).unwrap();
 }
 
-static mut info_fn: fn (&str) = to_stdout;
-static mut error_fn: fn (&str) = to_stderr;
+static mut info_fn: fn(&str) = to_stdout;
+static mut error_fn: fn(&str) = to_stderr;
 
 unsafe extern "C" fn error_wrapper(msg: *const i8) {
     let msg = ffi::CStr::from_ptr(msg).to_str().unwrap();
@@ -26,7 +26,7 @@ unsafe extern "C" fn info_wrapper(msg: *const i8) {
 
 static ARE_CALLBACKS_SET: Once = ONCE_INIT;
 /// TODO: Provide better API for this functionality
-pub fn set_info_callbacks(info: Option<fn (&str)>, error: Option<fn (&str)>) {
+pub fn set_info_callbacks(info: Option<fn(&str)>, error: Option<fn(&str)>) {
     unsafe {
         info_fn = info.unwrap_or(to_stdout);
         error_fn = error.unwrap_or(to_stderr);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub use callbacks::JackHandler;
 pub use client::Client;
 pub use enums::*;
 pub use flags::*;
-pub use port::Port;
+pub use port::{Port, Input, Output, UnknownOwned, Unowned, port_name_size, port_type_size};
 pub use info::set_info_callbacks;
 
 pub fn get_time() -> u64 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ mod info;
 mod port;
 mod utils;
 
-pub use callbacks::JackHandler;
+pub use callbacks::{JackHandler, ProcessScope};
 pub use client::{Client, ActiveClient, JackClient, client_name_size};
 pub use enums::*;
 pub use flags::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub use callbacks::{JackHandler, ProcessScope};
 pub use client::{Client, ActiveClient, JackClient, client_name_size};
 pub use enums::*;
 pub use flags::*;
-pub use port::{Port, Input, Output, UnknownOwned, Unowned, port_name_size, port_type_size};
+pub use port::{Port, Owned, Unowned, Input, Output, Audio, port_name_size, port_type_size};
 pub use info::set_info_callbacks;
 
 pub fn get_time() -> u64 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ mod port;
 mod utils;
 
 pub use callbacks::JackHandler;
-pub use client::Client;
+pub use client::{Client, ActiveClient, JackClient, client_name_size};
 pub use enums::*;
 pub use flags::*;
 pub use port::{Port, Input, Output, UnknownOwned, Unowned, port_name_size, port_type_size};

--- a/src/port.rs
+++ b/src/port.rs
@@ -1,66 +1,240 @@
 use std::{ffi, slice};
 use jack_sys as j;
+use client::Client;
+use callbacks::JackHandler;
 use flags::*;
 use enums::*;
 use utils;
+use std::marker::PhantomData;
+use std::mem::transmute;
+
+/// The maximum length of a full Jack port name. Unlike the "C" Jack API,
+/// this does not count the `NULL` character and corresponds to a string's
+/// `.len()`.
+///
+/// The port's full name contains the owning client name concatenated with a
+/// colon (:) followed by its short name.
+///
+/// This value is constant
+pub fn port_name_size() -> usize {
+    let s = unsafe { j::jack_port_name_size() - 1 };
+    s as usize
+}
+
+/// The maximum length of a port type. Unlike the "C" Jack API, this does
+/// not count the `NULL` character and corresponds to a string's `.len()`.
+///
+/// This value is constant.
+pub fn port_type_size() -> usize {
+    let s = unsafe { j::jack_port_type_size() - 1 };
+    s as usize
+}
+
+pub unsafe fn port_pointer<K: PortKind>(port: &Port<K>) -> *mut j::jack_port_t {
+    port.port
+}
 
 /// Converts a jack client handle and jack port handle in a `Port`. If either
 /// `client` or `port` is `null`, then `None` is returned.
 pub unsafe fn ptrs_to_port(client: *mut j::jack_client_t,
                            port: *mut j::jack_port_t)
-                           -> Option<Port> {
+                           -> Option<Port<Unowned>> {
     if client.is_null() || port.is_null() {
         None
     } else {
         Some(Port {
             client: client,
             port: port,
+            _kind: PhantomData,
+            buffer_size: 0,
         })
     }
 }
 
-pub unsafe fn port_pointer(port: &Port) -> *mut j::jack_port_t {
-    port.port
+/// Returns a pointer to the memory area associated with the specified
+/// port. For an output port, it will be a memory area that can be written
+/// to; for an input port, it will be an area containing the data from the
+/// port's connection(s), or zero-filled. If there are multiple inbound
+/// connections, the data will be mixed appropriately.
+///
+/// Do not cache the returned address across `process()` calls. Port buffers
+/// have to be retrieved in each callback for proper functioning.
+/// The provided port must be owned and valid for the lifetime of the result.
+pub unsafe fn buffer(port: *mut j::jack_port_t, n_frames: u32) -> *mut ::libc::c_void {
+    j::jack_port_get_buffer(port, n_frames)
+}
+
+pub trait PortKind {}
+pub unsafe trait OwnedPortKind: PortKind {
+    fn necessary_flags() -> PortFlags;
+}
+
+pub struct Input;
+pub struct Output;
+pub struct UnknownOwned;
+pub struct Unowned;
+
+impl PortKind for Input {}
+impl PortKind for Output {}
+impl PortKind for UnknownOwned {}
+impl PortKind for Unowned {}
+
+unsafe impl OwnedPortKind for Input {
+    fn necessary_flags() -> PortFlags { IS_INPUT }
+}
+unsafe impl OwnedPortKind for Output {
+    fn necessary_flags() -> PortFlags { IS_OUTPUT }
+}
+unsafe impl OwnedPortKind for UnknownOwned {
+    fn necessary_flags() -> PortFlags { NO_PORT_FLAGS }
+}
+
+pub unsafe fn claim_kind<B: PortKind, A: PortKind>(port: Port<B>) -> Port<A> {
+    transmute(port)
 }
 
 /// An endpoint to interact with Jack data streams, for audio, midi, etc...
-#[derive(Debug, Clone, Copy)]
-pub struct Port {
+#[derive(Debug)]
+pub struct Port<Kind: PortKind> {
+    // The client that created the given port.
+    // Only to be used to check that the client passed in to mutative
+    // methods is the same as the client that created the port.
     client: *mut j::jack_client_t,
+
+    // The Jack port itself
     port: *mut j::jack_port_t,
+
+    // Input, Output, UnknownOwned, or Unowned
+    // This stores the type that describes how the port can be used
+    _kind: PhantomData<Kind>,
+
+    // The current size of the buffer (n_frames) to be used to ensure
+    // safe slicing
+    buffer_size: u32,
 }
 
-impl Port {
-    /// The maximum length of a full Jack port name. Unlike the "C" Jack API,
-    /// this does not count the `NULL` character and corresponds to a string's
-    /// `.len()`.
-    ///
-    /// The port's full name contains the owning client name concatenated with a
-    /// colon (:) followed by its short name.
-    ///
-    /// This value is constant
-    pub fn name_size() -> usize {
-        let s = unsafe { j::jack_port_name_size() - 1 };
-        s as usize
+// It's only safe to change the given port as long as there are no other
+// references to the port. The client must be the client used to create
+// the port and must also be alive for the duration of the borrow.
+pub fn port_mut_pointer<'a, OKind: OwnedPortKind, T: JackHandler>(
+    port: &'a mut Port<OKind>, owner_client: &'a Client<T>) -> &'a mut j::jack_port_t {
+    unsafe {
+        assert_eq!(
+            owner_client.client_ptr() as *const j::jack_client_t,
+            port.client as *const j::jack_client_t);
+        transmute(port.port)
     }
+}
 
-    /// The maximum length of a port type. Unlike the "C" Jack API, this does
-    /// not count the `NULL` character and corresponds to a string's `.len()`.
-    ///
-    /// This value is constant.
-    pub fn type_size() -> usize {
-        let s = unsafe { j::jack_port_type_size() - 1 };
-        s as usize
+impl Port<Input> {
+    pub fn input_buffer(&self) -> &[f32] {
+        unsafe {
+            let buffer = buffer(self.port, self.buffer_size) as *const f32;
+            slice::from_raw_parts(buffer, self.buffer_size as usize)
+        }
     }
+}
 
+impl Port<Output> {
+    pub fn output_buffer(&mut self) -> &mut [f32] {
+        unsafe {
+            let buffer = buffer(self.port, self.buffer_size) as *mut f32;
+            slice::from_raw_parts_mut(buffer, self.buffer_size as usize)
+        }
+    }
+}
+
+// These functions mutate the Port, and should only be usable if we are
+// the owner.
+impl<OKind: OwnedPortKind> Port<OKind> {
     /// Remove the port from the client, disconnecting any existing connections.
-    pub fn unregister(self) -> Result<(), JackErr> {
-        let res = unsafe { j::jack_port_unregister(self.client, self.port) };
+    /// The port must have been created with the provided client.
+    pub fn unregister<T: JackHandler>(self, client: &mut Client<T>) -> Result<(), JackErr> {
+        let res = unsafe {
+            assert_eq!(client.client_ptr() as *const j::jack_client_t, self.client as *const j::jack_client_t);
+            j::jack_port_unregister(self.client, self.port)
+        };
         match res {
             0 => Ok(()),
             _ => Err(JackErr::CallbackDeregistrationError),
         }
     }
+
+    /// Set's the short name of the port. If the full name is longer than
+    /// `Port::name_size()`, then it will be truncated.
+    pub fn set_name(&mut self, short_name: &str) -> Result<(), JackErr> {
+        let short_name = ffi::CString::new(short_name).unwrap();
+        let res = unsafe { j::jack_port_set_name(self.port, short_name.as_ptr()) };
+        match res {
+            0 => Ok(()),
+            _ => Err(JackErr::PortNamingError),
+        }
+    }
+
+    /// Sets `alias` as an alias for `self`.
+    ///
+    /// May be called at any time. If the alias is longer than
+    /// `Client::name_size()`, it will be truncated.
+    ///
+    /// After a successful call, and until Jack exists, or the alias is unset,
+    /// `alias` may be used as an alternate name for the port.
+    ///
+    /// Ports can have up to two aliases - if both are already set, this
+    /// function will return an error.
+    pub fn set_alias(&self, alias: &str) -> Result<(), JackErr> {
+        let alias = ffi::CString::new(alias).unwrap();
+        let res = unsafe { j::jack_port_set_alias(self.port, alias.as_ptr()) };
+        match res {
+            0 => Ok(()),
+            _ => Err(JackErr::PortAliasError),
+        }
+    }
+
+    /// Remove `alias` as an alias for port. May be called at any time.
+    ///
+    /// After a successful call, `alias` can no longer be used as an alternate
+    /// name for `self`.
+    pub fn unset_alias(&self, alias: &str) -> Result<(), JackErr> {
+        let alias = ffi::CString::new(alias).unwrap();
+        let res = unsafe { j::jack_port_unset_alias(self.port, alias.as_ptr()) };
+        match res {
+            0 => Ok(()),
+            _ => Err(JackErr::PortAliasError),
+        }
+    }
+
+    /// Turn input monitoring for the port on or off.
+    ///
+    /// This only works if the port has the `CAN_MONITOR` flag set.
+    pub fn request_monitor(&self, enable_monitor: bool) -> Result<(), JackErr> {
+        let onoff = match enable_monitor {
+            true => 1,
+            false => 0,
+        };
+        let res = unsafe { j::jack_port_request_monitor(self.port, onoff) };
+        match res {
+            0 => Ok(()),
+            _ => Err(JackErr::PortMonitorError),
+        }
+    }
+
+    /// Perform the same function as `Client::disconnect_ports()`, but with a
+    /// port handle instead.
+    ///
+    /// Avoids the name lookup inherent in the name-based version.
+    ///
+    /// Clients connecting their own ports are likely to use this function,
+    /// while generic connection clients (e.g. patchbays) would use
+    /// `Client::disconnect_ports()`.
+    pub fn disconnect(self) -> Result<(), JackErr> {
+        match unsafe { j::jack_port_disconnect(self.client, self.port) } {
+            0 => Ok(()),
+            _ => Err(JackErr::PortDisconnectionError),
+        }
+    }
+}
+
+impl<Kind: PortKind> Port<Kind> {
 
     /// Returns the full name of the port, including the "client_name:" prefix.
     pub fn name<'a>(&'a self) -> &'a str {
@@ -119,9 +293,9 @@ impl Port {
     ///
     /// * Can't be used in the callback for graph reordering under certain
     /// conditions.
-    pub unsafe fn connections(&self) -> Vec<String> {
+    pub unsafe fn connections<T: JackHandler>(&self, client: &Client<T>) -> Vec<String> {
         let connections_ptr = {
-            let ptr = if j::jack_port_is_mine(self.client, self.port) != 0 {
+            let ptr = if j::jack_port_is_mine(self.client, self.port) == 1 {
                 j::jack_port_get_connections(self.port)
             } else {
                 j::jack_port_get_all_connections(self.client, self.port)
@@ -148,64 +322,6 @@ impl Port {
         }
     }
 
-    /// Set's the short name of the port. If the full name is longer than
-    /// `Port::name_size()`, then it will be truncated.
-    pub fn set_name(&self, short_name: &str) -> Result<(), JackErr> {
-        let short_name = ffi::CString::new(short_name).unwrap();
-        let res = unsafe { j::jack_port_set_name(self.port, short_name.as_ptr()) };
-        match res {
-            0 => Ok(()),
-            _ => Err(JackErr::PortNamingError),
-        }
-    }
-
-    /// Sets `alias` as an alias for `self`.
-    ///
-    /// May be called at any time. If the alias is longer than
-    /// `Client::name_size()`, it will be truncated.
-    ///
-    /// After a successful call, and until Jack exists, or the alias is unset,
-    /// `alias` may be used as an alternate name for the port.
-    ///
-    /// Ports can have up to two aliases - if both are already set, this
-    /// function will return an error.
-    pub fn set_alias(&self, alias: &str) -> Result<(), JackErr> {
-        let alias = ffi::CString::new(alias).unwrap();
-        let res = unsafe { j::jack_port_set_alias(self.port, alias.as_ptr()) };
-        match res {
-            0 => Ok(()),
-            _ => Err(JackErr::PortAliasError),
-        }
-    }
-
-    /// Remove `alias` as an alias for port. May be called at any time.
-    ///
-    /// After a successful call, `alias` can no longer be used as an alternate
-    /// name for `self`.
-    pub fn unset_alias(&self, alias: &str) -> Result<(), JackErr> {
-        let alias = ffi::CString::new(alias).unwrap();
-        let res = unsafe { j::jack_port_unset_alias(self.port, alias.as_ptr()) };
-        match res {
-            0 => Ok(()),
-            _ => Err(JackErr::PortAliasError),
-        }
-    }
-
-    /// Turn input monitoring for the port on or off.
-    ///
-    /// This only works if the port has the `CAN_MONITOR` flag set.
-    pub fn request_monitor(&self, enable_monitor: bool) -> Result<(), JackErr> {
-        let onoff = match enable_monitor {
-            true => 1,
-            false => 0,
-        };
-        let res = unsafe { j::jack_port_request_monitor(self.port, onoff) };
-        match res {
-            0 => Ok(()),
-            _ => Err(JackErr::PortMonitorError),
-        }
-    }
-
     /// If the `CAN_MONITOR` flag is set for the port, then input monitoring is
     /// turned on if it was off, and turns it off if only one request has been
     /// made to turn it on. Otherwise it does nothing.
@@ -219,45 +335,5 @@ impl Port {
             0 => Ok(()),
             _ => Err(JackErr::PortMonitorError),
         }
-    }
-
-    /// Perform the same function as `Client::disconnect_ports()`, but with a
-    /// port handle instead.
-    ///
-    /// Avoids the name lookup inherent in the name-based version.
-    ///
-    /// Clients connecting their own ports are likely to use this function,
-    /// while generic connection clients (e.g. patchbays) would use
-    /// `Client::disconnect_ports()`.
-    pub fn disconnect(&self) -> Result<(), JackErr> {
-        match unsafe { j::jack_port_disconnect(self.client, self.port) } {
-            0 => Ok(()),
-            _ => Err(JackErr::PortDisconnectionError),
-        }
-    }
-
-    /// Returns a pointer to the memory area associated with the specified
-    /// port. For an output port, it will be a memory area that can be written
-    /// to; for an input port, it will be an area containing the data from the
-    /// port's connection(s), or zero-filled. If there are multiple inbound
-    /// connections, the data will be mixed appropriately.
-    ///
-    /// Do not cache the returned address across `process()` calls. Port buffers
-    /// have to be retrieved in each callback for proper functioning.
-    pub unsafe fn buffer(&self, n_frames: u32) -> *mut ::libc::c_void {
-        j::jack_port_get_buffer(self.port, n_frames)
-    }
-
-    /// Interprets the buffer as a slice of type `T` with length `n_frames`.
-    pub unsafe fn as_slice<T>(&self, n_frames: u32) -> &[T] {
-        let buffer = self.buffer(n_frames) as *const T;
-        slice::from_raw_parts(buffer, n_frames as usize)
-    }
-
-    /// Interprets the buffer as a mutable slice of type `T` with length
-    /// `n_frames`.
-    pub unsafe fn as_slice_mut<T>(&self, n_frames: u32) -> &mut [T] {
-        let buffer = self.buffer(n_frames) as *mut T;
-        slice::from_raw_parts_mut(buffer, n_frames as usize)
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -16,9 +16,7 @@ struct TestHandler {
 
 impl TestHandler {
     pub fn new() -> Self {
-        TestHandler {
-            callbacks_used: HashSet::new(),
-        }
+        TestHandler { callbacks_used: HashSet::new() }
     }
 }
 
@@ -69,7 +67,7 @@ fn test() {
     let expected_called = ["thread_init", "process"];
     for s in expected_called.iter() {
         assert!(tested_handler.callbacks_used.contains(s));
-    };
+    }
 
     // close
     deactivated_client.close();

--- a/src/test.rs
+++ b/src/test.rs
@@ -54,8 +54,8 @@ fn test() {
     set_info_callbacks(Some(info_handler), Some(error_handler));
 
     // create client
-    let mut client = Client::open("rj-test", NO_START_SERVER).unwrap();
-    assert_eq!(client.status(), ClientStatus::empty());
+    let (mut client, status) = Client::open("rj-test", NO_START_SERVER).unwrap();
+    assert_eq!(status, ClientStatus::empty());
     assert_eq!(client.name(), "rj-test");
 
     // query parameters

--- a/src/test.rs
+++ b/src/test.rs
@@ -31,7 +31,7 @@ impl JackHandler for TestHandler {
         self.callbacks_used.insert("shutdown");
     }
 
-    fn process(&mut self, _: u32) -> JackControl {
+    fn process(&mut self, _: &mut ProcessScope) -> JackControl {
         self.callbacks_used.insert("process");
         JackControl::Continue
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -43,7 +43,7 @@ impl JackHandler for TestHandler {
 
 #[test]
 fn static_fns() {
-    Client::<TestHandler>::name_size();
+    client_name_size();
     port_name_size();
     port_type_size();
 }
@@ -54,7 +54,7 @@ fn test() {
     set_info_callbacks(Some(info_handler), Some(error_handler));
 
     // create client
-    let (mut client, status) = Client::open("rj-test", NO_START_SERVER).unwrap();
+    let (client, status) = Client::open("rj-test", NO_START_SERVER).unwrap();
     assert_eq!(status, ClientStatus::empty());
     assert_eq!(client.name(), "rj-test");
 
@@ -63,14 +63,14 @@ fn test() {
     let _midi_type_buffer_size = unsafe { client.type_buffer_size(DEFAULT_MIDI_TYPE) };
 
     // test run
-    client.activate(TestHandler::new()).unwrap();
+    let activated_client = client.activate(TestHandler::new()).unwrap();
     thread::sleep(time::Duration::from_secs(1));
-    let tested_handler = client.deactivate().unwrap();
+    let (deactivated_client, tested_handler) = activated_client.deactivate().unwrap();
     let expected_called = ["thread_init", "process"];
     for s in expected_called.iter() {
         assert!(tested_handler.callbacks_used.contains(s));
     };
 
     // close
-    client.close();
+    deactivated_client.close();
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -44,8 +44,8 @@ impl JackHandler for TestHandler {
 #[test]
 fn static_fns() {
     Client::<TestHandler>::name_size();
-    Port::name_size();
-    Port::type_size();
+    port_name_size();
+    port_type_size();
 }
 
 #[test]


### PR DESCRIPTION
Reworked `Port`, `Client` and `JackHandler` to allow for safe access to the input and output buffers in the `process` callback function. Split up `Client` into `Client` and `ActiveClient` to prevent modification to `Client` while audio is being processed.

@wmedrano I haven't had a chance to do a final pass-through and cleanup, but I'm at a point now where I'd appreciate your thoughts when you get a chance to glance through.