### PR TITLE
Make ProcessCallbacks struct public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ pub mod contrib {
     mod closure;
 
     pub use closure::ClosureProcessHandler;
+    pub use closure::ProcessCallbacks;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
**Changes:**

Made `ProcessCallbacks` public in `lib.rs`.

**Why?**

When creating an `AsyncClient` using `client.activate_async` and using a handler with state, the `ProcessCallbacks` type is needed if you want to annotate the type of the `AsyncClient`

For example:

```rust
fn some_function(
) -> anyhow::Result<AsyncClient<Notifications, ClosureProcessHandler<State, ProcessCallbacks<impl FnMut(&mut State, &Client, &ProcessScope) -> Control, impl FnMut(&mut State, &Client, Frames) -> Control>>>> {
    let process_callback = move |state: &mut State, client: &Client, ps: &ProcessScope| -> Control {
        Control::Continue
    };
    let buffer_callback = |state: &mut State, client: &Client, len: Frames| -> Control {
        Control::Continue
    };

    let handler = ClosureProcessHandler::with_state(Jack::default(), process_callback, buffer_callback);
    let active_client = client.activate_async(notifications, handler)?;

    Ok(active_client)
}

```