### PR TITLE
Remove `PartialEq` attribute for `LoggerType`

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -12,7 +12,7 @@ pub(crate) fn maybe_init_logging() {
 }
 
 /// Describes how JACK should log info and error messages.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug)]
 pub enum LoggerType {
     /// Ignore all logging from JACK.
     None,


### PR DESCRIPTION
`LoggerType` contains function pointers.  `PartialEq` is not meaningful for function pointers.

