### PR TITLE
Increase timeout for `client_callbacks` test

### DIFF
--- a/src/properties.rs
+++ b/src/properties.rs
@@ -481,7 +481,7 @@ mod metadata {
 
         #[test]
         fn client_callbacks() {
-            let timeout = std::time::Duration::from_millis(10);
+            let timeout = std::time::Duration::from_millis(50);
             let prop1 = Property::new("foo", None);
             let prop2 = Property::new(
                 "http://churchofrobotron.com/2084",


### PR DESCRIPTION
From 10ms to 50ms

Jack is too slow to load properties in 10ms on a Raspberry Pi 5 (aarch64)

See [this issue](https://github.com/RustAudio/rust-jack/issues/184#issuecomment-3762455798)

The properties are loaded using  Berkeley DB, probably why